### PR TITLE
Improve Fabric Mod compatibility data

### DIFF
--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -36,6 +36,7 @@
   "breaks": {
     "bedrockwaters": "*",
     "forcecloseworldloadingscreen": "*"
+    "rrls": "*"
   },
   "conflicts": {
     "lemclienthelper": "*"

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -38,6 +38,7 @@
     "bedrockwaters": "*",
     "forcecloseworldloadingscreen": "*"
     "rrls": "*"
+    "bedrockify": "*":
   },
   "conflicts": {
     "lemclienthelper": "*"

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -38,7 +38,8 @@
     "bedrockwaters": "*",
     "forcecloseworldloadingscreen": "*"
     "rrls": "*"
-    "bedrockify": "*":
+    "bedrockify": "*"
+    "embeddium": "*"
   },
   "conflicts": {
     "lemclienthelper": "*"

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -39,6 +39,7 @@
     "forcecloseworldloadingscreen": "*"
     "rrls": "*"
     "bedrockify": "*"
+    "fancymenu": "*"
   },
   "conflicts": {
     "lemclienthelper": "*"

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -39,12 +39,12 @@
     "forcecloseworldloadingscreen": "*"
     "rrls": "*"
     "bedrockify": "*"
-    "embeddium": "*"
   },
   "conflicts": {
     "lemclienthelper": "*"
     "sodium-extra": "*"
     "reeses-sodium-options": "*"
     "modmenu": "*"
+    "embeddium": "*"
   }
 }

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -9,6 +9,7 @@
   ],
   "contributors": [
     "${mod_credits}"
+    "omo50"
   ],
   "contact": {
     "sources": "${mod_source}"
@@ -40,5 +41,8 @@
   },
   "conflicts": {
     "lemclienthelper": "*"
+    "sodium-extra": "*"
+    "reeses-sodium-options": "*"
+    "modmenu": "*"
   }
 }


### PR DESCRIPTION
This adds breaks/conflicts clauses with many mods that are incompatible/dont work with L4J
one of these is also broken on forge, but that goes beyond my knowledge of expertise. That mod being rrls/Remove Reloading Screen

I was unable to *properly* test this, but it should work. Thank you, please review it thouroughly