### PR TITLE
Fix a renderer crash with worlds that don't extend the vanilla client world

### DIFF
--- a/fabric/src/main/java/wily/legacy/fabric/mixin/LiquidBlockRendererMixin.java
+++ b/fabric/src/main/java/wily/legacy/fabric/mixin/LiquidBlockRendererMixin.java
@@ -20,6 +20,9 @@ public class LiquidBlockRendererMixin {
     @Redirect(method = "tesselate",at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/block/LiquidBlockRenderer;vertex(Lcom/mojang/blaze3d/vertex/VertexConsumer;DDDFFFFFI)V"))
     public void tesselate(LiquidBlockRenderer instance, VertexConsumer vertexConsumer, double d, double e, double f, float g, float h, float i, float j, float k, int l, BlockAndTintGetter getter, BlockPos pos, VertexConsumer arg3, BlockState state, FluidState arg5) {
         LevelReader reader = getter instanceof RenderChunkRegion r ? r.level : getter instanceof LevelAccessor a ? a : null;
-        vertexConsumer.vertex(d, e, f).color(g, h, i, arg5.is(Fluids.WATER) || arg5.is(Fluids.FLOWING_WATER) ?  LegacyBiomeOverride.getOrDefault(reader.getBiome(pos).unwrapKey()).waterTransparency() : 1.0f).uv(j, k).uv2(l).normal(0.0f, 1.0f, 0.0f).endVertex();
+        if (reader != null)
+            vertexConsumer.vertex(d, e, f).color(g, h, i, arg5.is(Fluids.WATER) || arg5.is(Fluids.FLOWING_WATER) ?  LegacyBiomeOverride.getOrDefault(reader.getBiome(pos).unwrapKey()).waterTransparency() : 1.0f).uv(j, k).uv2(l).normal(0.0f, 1.0f, 0.0f).endVertex();
+        else
+            vertexConsumer.vertex(d, e, f).color(g, h, i, 1.0f).uv(j, k).uv2(l).normal(0.0f, 1.0f, 0.0f).endVertex();
     }
 }


### PR DESCRIPTION
This is meant to fix a crash that happens with Litematica installed. Possibly the same issue as in #378.

However I haven't tested if this fixes all issues, as apparently running `gradlew build` doesn't actually build the proper jar? It gave me an almost empty jar that was only 261 bytes in size. I don't know how this Architectury-Loom tool chain works...