### PR TITLE
pressing X while looking at a crafting table should always show the crafting menu

### DIFF
--- a/src/main/java/wily/legacy/Legacy4JClient.java
+++ b/src/main/java/wily/legacy/Legacy4JClient.java
@@ -320,7 +320,7 @@ public class Legacy4JClient {
                 else minecraft.setScreen(CreativeModeScreen.getActualCreativeScreenInstance(minecraft));
                 continue;
             }
-            if (minecraft.hitResult instanceof BlockHitResult r && minecraft.level.getBlockState(r.getBlockPos()).getBlock() instanceof CraftingTableBlock && !activeControlType.isKbm()){
+            if (minecraft.hitResult instanceof BlockHitResult r && minecraft.level.getBlockState(r.getBlockPos()).getBlock() instanceof CraftingTableBlock && controllerManager.isControllerTheLastInput()){
                 minecraft.gameMode.useItemOn(minecraft.player, InteractionHand.MAIN_HAND, r);
             } else if (ScreenUtil.hasClassicCrafting()) {
                 minecraft.getTutorial().onOpenInventory();

--- a/src/main/java/wily/legacy/Legacy4JClient.java
+++ b/src/main/java/wily/legacy/Legacy4JClient.java
@@ -320,8 +320,11 @@ public class Legacy4JClient {
                 else minecraft.setScreen(CreativeModeScreen.getActualCreativeScreenInstance(minecraft));
                 continue;
             }
-            if (minecraft.hitResult instanceof BlockHitResult r && minecraft.level.getBlockState(r.getBlockPos()).getBlock() instanceof CraftingTableBlock){
+            if (minecraft.hitResult instanceof BlockHitResult r && minecraft.level.getBlockState(r.getBlockPos()).getBlock() instanceof CraftingTableBlock && !activeControlType.isKbm()){
                 minecraft.gameMode.useItemOn(minecraft.player, InteractionHand.MAIN_HAND, r);
+            } else if (ScreenUtil.hasClassicCrafting()) {
+                minecraft.getTutorial().onOpenInventory();
+                minecraft.setScreen(new InventoryScreen(minecraft.player));
             } else if (ScreenUtil.hasMixedCrafting()) {
                 minecraft.setScreen(MixedCraftingScreen.playerCraftingScreen(minecraft.player));
             } else CommonNetwork.sendToServer(ServerOpenClientMenuPayload.playerCrafting());

--- a/src/main/java/wily/legacy/Legacy4JClient.java
+++ b/src/main/java/wily/legacy/Legacy4JClient.java
@@ -320,16 +320,11 @@ public class Legacy4JClient {
                 else minecraft.setScreen(CreativeModeScreen.getActualCreativeScreenInstance(minecraft));
                 continue;
             }
-            if (ScreenUtil.hasClassicCrafting()) {
-                minecraft.getTutorial().onOpenInventory();
-                minecraft.setScreen(new InventoryScreen(minecraft.player));
-            }else {
-                if (minecraft.hitResult instanceof BlockHitResult r && minecraft.level.getBlockState(r.getBlockPos()).getBlock() instanceof CraftingTableBlock){
-                    minecraft.gameMode.useItemOn(minecraft.player, InteractionHand.MAIN_HAND, r);
-                } else if (ScreenUtil.hasMixedCrafting()) {
-                    minecraft.setScreen(MixedCraftingScreen.playerCraftingScreen(minecraft.player));
-                } else CommonNetwork.sendToServer(ServerOpenClientMenuPayload.playerCrafting());
-            }
+            if (minecraft.hitResult instanceof BlockHitResult r && minecraft.level.getBlockState(r.getBlockPos()).getBlock() instanceof CraftingTableBlock){
+                minecraft.gameMode.useItemOn(minecraft.player, InteractionHand.MAIN_HAND, r);
+            } else if (ScreenUtil.hasMixedCrafting()) {
+                minecraft.setScreen(MixedCraftingScreen.playerCraftingScreen(minecraft.player));
+            } else CommonNetwork.sendToServer(ServerOpenClientMenuPayload.playerCrafting());
         }
         while (keyHostOptions.consumeClick()) {
             minecraft.setScreen(new HostOptionsScreen());


### PR DESCRIPTION
Pressing the crafting button while looking at a crafting table should interact with it regardless of the classic crafting setting (checked on TU75, Xbox 360). This only works on controller, on keyboard the button opens the inventory as usual