### PR TITLE
fix item pickup particle in 1.21.4 and above

### DIFF
--- a/src/main/java/wily/legacy/mixin/base/ItemPickupParticleMixin.java
+++ b/src/main/java/wily/legacy/mixin/base/ItemPickupParticleMixin.java
@@ -28,7 +28,11 @@ public abstract class ItemPickupParticleMixin extends Particle {
         if (LegacyOptions.legacyItemPickup.get()) lifetime += level.random.nextInt(8);
     }
 
+    //? if <1.21.4 {
     @ModifyVariable(method = "render", at = @At("STORE"), index = 4)
+    //?} else {
+    /*@ModifyVariable(method = "renderCustom", at = @At("STORE"), index = 5)
+    *///?}
     public float render(float original, @Local(ordinal = 0, argsOnly = true) float partialTick) {
         return LegacyOptions.legacyItemPickup.get() ? ((float) this.life + partialTick) / lifetime : original;
     }


### PR DESCRIPTION
this is a hotfix for the random item pickup speed, the render method used in 1.21.4 and above is `renderCustom`