### PR TITLE
Fix not having enough GUI Entity Renderers in the Leaderboards screen

### DIFF
--- a/src/main/java/wily/legacy/mixin/base/client/GuiRendererMixin.java
+++ b/src/main/java/wily/legacy/mixin/base/client/GuiRendererMixin.java
@@ -55,6 +55,16 @@ public class GuiRendererMixin {
                 new GuiEntityRenderer(bufferSource, Minecraft.getInstance().getEntityRenderDispatcher()),
                 new GuiEntityRenderer(bufferSource, Minecraft.getInstance().getEntityRenderDispatcher()),
                 new GuiEntityRenderer(bufferSource, Minecraft.getInstance().getEntityRenderDispatcher()),
+                new GuiEntityRenderer(bufferSource, Minecraft.getInstance().getEntityRenderDispatcher()),
+                new GuiEntityRenderer(bufferSource, Minecraft.getInstance().getEntityRenderDispatcher()),
+                new GuiEntityRenderer(bufferSource, Minecraft.getInstance().getEntityRenderDispatcher()),
+                new GuiEntityRenderer(bufferSource, Minecraft.getInstance().getEntityRenderDispatcher()),
+                new GuiEntityRenderer(bufferSource, Minecraft.getInstance().getEntityRenderDispatcher()),
+                new GuiEntityRenderer(bufferSource, Minecraft.getInstance().getEntityRenderDispatcher()),
+                new GuiEntityRenderer(bufferSource, Minecraft.getInstance().getEntityRenderDispatcher()),
+                new GuiEntityRenderer(bufferSource, Minecraft.getInstance().getEntityRenderDispatcher()),
+                new GuiEntityRenderer(bufferSource, Minecraft.getInstance().getEntityRenderDispatcher()),
+                new GuiEntityRenderer(bufferSource, Minecraft.getInstance().getEntityRenderDispatcher()),
                 new GuiEntityRenderer(bufferSource, Minecraft.getInstance().getEntityRenderDispatcher())
         );
     }


### PR DESCRIPTION
- Now 20 entities can be rendered in a GUI in a single frame.