### PR TITLE
fixed resourcepacks dependant on vanilla shader pipeline e.g halloween mash up clouds

### DIFF
--- a/src/main/java/wily/legacy/client/LegacyCloudAtmosphere.java
+++ b/src/main/java/wily/legacy/client/LegacyCloudAtmosphere.java
@@ -5,6 +5,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.renderer.DimensionSpecialEffects;
 import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.ARGB;
 import net.minecraft.util.Mth;
 import net.minecraft.world.level.biome.Biome;
@@ -13,6 +14,7 @@ import org.joml.Vector3f;
 
 public final class LegacyCloudAtmosphere {
     private static final float TWO_PI = 6.2831855f;
+    private static final ResourceLocation VANILLA_CLOUD_SHADER = ResourceLocation.withDefaultNamespace("shaders/core/rendertype_clouds.fsh");
 
     private static final class CloudGeometry {
         private static final float LEGACY_HEIGHT = 128.0f;
@@ -32,7 +34,6 @@ public final class LegacyCloudAtmosphere {
     }
 
     private static final class FogTuning {
-        private static final int DEFAULT_COLOR = 0xFFC0D8FF;
         private static final float SUNRISE_TINT_STRENGTH = 0.96f;
 
         private FogTuning() {
@@ -87,6 +88,11 @@ public final class LegacyCloudAtmosphere {
         return getSunriseCloudViewBlend(level, sampledPartialTick) > warmViewThreshold;
     }
 
+    public static boolean shouldUsePackCloudShader() {
+        Minecraft minecraft = Minecraft.getInstance();
+        return minecraft.getResourceManager().getResourceStack(VANILLA_CLOUD_SHADER).size() > 1;
+    }
+
     public static int getSkyColor(ClientLevel level, Vec3 position, float partialTick) {
         float brightness = getDayBrightness(level.getTimeOfDay(partialTick));
         BlockPos blockPos = BlockPos.containing(position.x, position.y, position.z);
@@ -113,7 +119,7 @@ public final class LegacyCloudAtmosphere {
     }
 
     public static int getAtmosphericFogColor(ClientLevel level, Camera camera, int renderDistanceChunks, float partialTick) {
-        float[] rgb = getDimensionFogRgb(level, partialTick);
+        float[] rgb = getDimensionFogRgb(level, camera, partialTick);
 
         if (renderDistanceChunks >= 4) {
             int sunriseColor = getSunriseColor(level.getTimeOfDay(partialTick));
@@ -183,12 +189,15 @@ public final class LegacyCloudAtmosphere {
         return ARGB.colorFromFloat(alpha, red, green, blue);
     }
 
-    private static float[] getDimensionFogRgb(ClientLevel level, float partialTick) {
+    private static float[] getDimensionFogRgb(ClientLevel level, Camera camera, float partialTick) {
         float brightness = getDayBrightness(level.getTimeOfDay(partialTick));
+        BlockPos blockPos = BlockPos.containing(camera.getPosition());
+        Biome biome = level.getBiome(blockPos).value();
+        Vec3 fogColor = level.effects().getBrightnessDependentFogColor(Vec3.fromRGB24(biome.getFogColor()), brightness);
         return new float[]{
-            ARGB.redFloat(FogTuning.DEFAULT_COLOR) * (brightness * 0.94f + 0.06f),
-            ARGB.greenFloat(FogTuning.DEFAULT_COLOR) * (brightness * 0.94f + 0.06f),
-            ARGB.blueFloat(FogTuning.DEFAULT_COLOR) * (brightness * 0.91f + 0.09f)
+            (float) fogColor.x,
+            (float) fogColor.y,
+            (float) fogColor.z
         };
     }
 

--- a/src/main/java/wily/legacy/client/LegacyRenderPipelines.java
+++ b/src/main/java/wily/legacy/client/LegacyRenderPipelines.java
@@ -44,6 +44,23 @@ public class LegacyRenderPipelines {
                     .withDepthWrite(true)
                     .build()
     );
+    public static final RenderPipeline LEGACY_PACK_FLAT_CLOUDS = RenderPipelinesAccessor.register(
+            RenderPipeline.builder(RenderPipelines.CLOUDS_SNIPPET)
+                    .withLocation(Legacy4J.createModLocation("pipeline/pack_flat_clouds"))
+                    .withVertexShader(Legacy4J.createModLocation("core/legacy_rendertype_clouds"))
+                    .withFragmentShader("core/rendertype_clouds")
+                    .withDepthWrite(true)
+                    .withCull(false)
+                    .build()
+    );
+    public static final RenderPipeline LEGACY_PACK_CLOUDS = RenderPipelinesAccessor.register(
+            RenderPipeline.builder(RenderPipelines.CLOUDS_SNIPPET)
+                    .withLocation(Legacy4J.createModLocation("pipeline/pack_clouds"))
+                    .withVertexShader(Legacy4J.createModLocation("core/legacy_rendertype_clouds"))
+                    .withFragmentShader("core/rendertype_clouds")
+                    .withDepthWrite(true)
+                    .build()
+    );
     public static final RenderPipeline GAMMA = RenderPipelinesAccessor.register(
             RenderPipeline.builder(RenderPipelines.POST_PROCESSING_SNIPPET)
                     .withLocation(Legacy4J.createModLocation("pipeline/gamma"))

--- a/src/main/java/wily/legacy/mixin/base/client/CloudRendererMixin.java
+++ b/src/main/java/wily/legacy/mixin/base/client/CloudRendererMixin.java
@@ -32,13 +32,17 @@ public abstract class CloudRendererMixin {
     @Unique
     private static final float CLOUD_BOTTOM_EXTENSION = 2.0f / 3.0f;
     @Unique
-    private static final int INSIDE_FACE_RADIUS = 1;
+    private static final float CLOUD_STATE_HYSTERESIS = 0.05f;
     @Unique
     private boolean legacy$lastLceCloudState;
     @Unique
     private boolean legacy$lastLegacyCloudHeightAndTextureState;
     @Unique
     private boolean legacy$lastPackCloudShaderState;
+    @Unique
+    private int legacy$currentRelativeCameraPos;
+    @Unique
+    private int legacy$lastRelativeCameraPos = Integer.MIN_VALUE;
     @Unique
     private boolean legacy$useWarmCloudPipelines;
 
@@ -55,10 +59,13 @@ public abstract class CloudRendererMixin {
         boolean lceCloudsEnabled = LegacyCloudAtmosphere.areLceCloudsEnabled();
         boolean legacyCloudHeightAndTextureEnabled = LegacyCloudAtmosphere.areLegacyCloudHeightAndTextureEnabled();
         boolean packCloudShaderEnabled = LegacyCloudAtmosphere.shouldUsePackCloudShader();
-        if (legacy$lastLceCloudState != lceCloudsEnabled || legacy$lastLegacyCloudHeightAndTextureState != legacyCloudHeightAndTextureEnabled || legacy$lastPackCloudShaderState != packCloudShaderEnabled) {
+        int relativeCameraPos = legacy$getRelativeCameraPos();
+        legacy$currentRelativeCameraPos = relativeCameraPos;
+        if (legacy$lastLceCloudState != lceCloudsEnabled || legacy$lastLegacyCloudHeightAndTextureState != legacyCloudHeightAndTextureEnabled || legacy$lastPackCloudShaderState != packCloudShaderEnabled || legacy$lastRelativeCameraPos != relativeCameraPos) {
             legacy$lastLceCloudState = lceCloudsEnabled;
             legacy$lastLegacyCloudHeightAndTextureState = legacyCloudHeightAndTextureEnabled;
             legacy$lastPackCloudShaderState = packCloudShaderEnabled;
+            legacy$lastRelativeCameraPos = relativeCameraPos;
             needsRebuild = true;
         }
     }
@@ -196,15 +203,9 @@ public abstract class CloudRendererMixin {
 
     @Unique
     private void legacy$buildSquareExtrudedCell(ByteBuffer buffer, int offsetX, int offsetZ, boolean emitTopAndBottomFaces, long cellData) {
-        int relativeCameraPos = legacy$getRelativeCameraPos();
-        boolean renderInsideFaces = relativeCameraPos == 0 && Math.abs(offsetX) <= INSIDE_FACE_RADIUS && Math.abs(offsetZ) <= INSIDE_FACE_RADIUS;
+        int relativeCameraPos = legacy$currentRelativeCameraPos;
+        boolean renderInsideFaces = relativeCameraPos == 0 && offsetX == 0 && offsetZ == 0;
         if (emitTopAndBottomFaces) {
-            if (renderInsideFaces) {
-                legacy$encodeFace(buffer, offsetX, offsetZ, Direction.UP, 16);
-                legacy$encodeFace(buffer, offsetX, offsetZ, Direction.DOWN, 16);
-                return;
-            }
-
             if (relativeCameraPos != -1) {
                 legacy$encodeFace(buffer, offsetX, offsetZ, Direction.UP, 0);
             }
@@ -212,24 +213,17 @@ public abstract class CloudRendererMixin {
             if (relativeCameraPos != 1) {
                 legacy$encodeFace(buffer, offsetX, offsetZ, Direction.DOWN, 0);
             }
+
+            if (renderInsideFaces) {
+                legacy$encodeFace(buffer, offsetX, offsetZ, Direction.UP, 16);
+                legacy$encodeFace(buffer, offsetX, offsetZ, Direction.DOWN, 16);
+            }
         } else {
             if (renderInsideFaces) {
-                if (legacy$isNorthEmpty(cellData)) {
-                    legacy$encodeFace(buffer, offsetX, offsetZ, Direction.NORTH, 16);
-                }
-
-                if (legacy$isSouthEmpty(cellData)) {
-                    legacy$encodeFace(buffer, offsetX, offsetZ, Direction.SOUTH, 16);
-                }
-
-                if (legacy$isWestEmpty(cellData)) {
-                    legacy$encodeFace(buffer, offsetX, offsetZ, Direction.WEST, 16);
-                }
-
-                if (legacy$isEastEmpty(cellData)) {
-                    legacy$encodeFace(buffer, offsetX, offsetZ, Direction.EAST, 16);
-                }
-                return;
+                legacy$encodeFace(buffer, offsetX, offsetZ, Direction.NORTH, 16);
+                legacy$encodeFace(buffer, offsetX, offsetZ, Direction.SOUTH, 16);
+                legacy$encodeFace(buffer, offsetX, offsetZ, Direction.WEST, 16);
+                legacy$encodeFace(buffer, offsetX, offsetZ, Direction.EAST, 16);
             }
 
             if (legacy$isNorthEmpty(cellData) && offsetZ > 0) {
@@ -260,11 +254,34 @@ public abstract class CloudRendererMixin {
 
         double cameraY = minecraft.gameRenderer.getMainCamera().getPosition().y;
         float cloudHeight = LegacyCloudAtmosphere.areLegacyCloudHeightAndTextureEnabled() ? LEGACY_CLOUD_HEIGHT : (float) minecraft.level.dimensionType().cloudHeight().orElse((int) LEGACY_CLOUD_HEIGHT);
-        if (cameraY > cloudHeight + CLOUD_BASE_HEIGHT + CLOUD_TOP_EXTENSION) {
+        double top = cloudHeight + CLOUD_BASE_HEIGHT + CLOUD_TOP_EXTENSION;
+        double bottom = cloudHeight - CLOUD_BOTTOM_EXTENSION;
+
+        if (legacy$lastRelativeCameraPos == 0) {
+            if (cameraY > top + CLOUD_STATE_HYSTERESIS) {
+                return 1;
+            }
+
+            if (cameraY < bottom - CLOUD_STATE_HYSTERESIS) {
+                return -1;
+            }
+
+            return 0;
+        }
+
+        if (legacy$lastRelativeCameraPos > 0) {
+            return cameraY > top - CLOUD_STATE_HYSTERESIS ? 1 : 0;
+        }
+
+        if (legacy$lastRelativeCameraPos < 0) {
+            return cameraY < bottom + CLOUD_STATE_HYSTERESIS ? -1 : 0;
+        }
+
+        if (cameraY > top) {
             return 1;
         }
 
-        if (cameraY < cloudHeight - CLOUD_BOTTOM_EXTENSION) {
+        if (cameraY < bottom) {
             return -1;
         }
 

--- a/src/main/java/wily/legacy/mixin/base/client/CloudRendererMixin.java
+++ b/src/main/java/wily/legacy/mixin/base/client/CloudRendererMixin.java
@@ -26,7 +26,11 @@ public abstract class CloudRendererMixin {
     @Unique
     private static final float LEGACY_CLOUD_HEIGHT = 128.0f;
     @Unique
-    private static final float CLOUD_LAYER_HEIGHT = 4.0f;
+    private static final float CLOUD_BASE_HEIGHT = 4.0f;
+    @Unique
+    private static final float CLOUD_TOP_EXTENSION = 0.25f;
+    @Unique
+    private static final float CLOUD_BOTTOM_EXTENSION = 2.0f / 3.0f;
     @Unique
     private static final int INSIDE_FACE_RADIUS = 1;
     @Unique
@@ -193,7 +197,14 @@ public abstract class CloudRendererMixin {
     @Unique
     private void legacy$buildSquareExtrudedCell(ByteBuffer buffer, int offsetX, int offsetZ, boolean emitTopAndBottomFaces, long cellData) {
         int relativeCameraPos = legacy$getRelativeCameraPos();
+        boolean renderInsideFaces = relativeCameraPos == 0 && Math.abs(offsetX) <= INSIDE_FACE_RADIUS && Math.abs(offsetZ) <= INSIDE_FACE_RADIUS;
         if (emitTopAndBottomFaces) {
+            if (renderInsideFaces) {
+                legacy$encodeFace(buffer, offsetX, offsetZ, Direction.UP, 16);
+                legacy$encodeFace(buffer, offsetX, offsetZ, Direction.DOWN, 16);
+                return;
+            }
+
             if (relativeCameraPos != -1) {
                 legacy$encodeFace(buffer, offsetX, offsetZ, Direction.UP, 0);
             }
@@ -201,12 +212,26 @@ public abstract class CloudRendererMixin {
             if (relativeCameraPos != 1) {
                 legacy$encodeFace(buffer, offsetX, offsetZ, Direction.DOWN, 0);
             }
-
-            if (relativeCameraPos == 0 && Math.abs(offsetX) <= INSIDE_FACE_RADIUS && Math.abs(offsetZ) <= INSIDE_FACE_RADIUS) {
-                legacy$encodeFace(buffer, offsetX, offsetZ, Direction.UP, 16);
-                legacy$encodeFace(buffer, offsetX, offsetZ, Direction.DOWN, 16);
-            }
         } else {
+            if (renderInsideFaces) {
+                if (legacy$isNorthEmpty(cellData)) {
+                    legacy$encodeFace(buffer, offsetX, offsetZ, Direction.NORTH, 16);
+                }
+
+                if (legacy$isSouthEmpty(cellData)) {
+                    legacy$encodeFace(buffer, offsetX, offsetZ, Direction.SOUTH, 16);
+                }
+
+                if (legacy$isWestEmpty(cellData)) {
+                    legacy$encodeFace(buffer, offsetX, offsetZ, Direction.WEST, 16);
+                }
+
+                if (legacy$isEastEmpty(cellData)) {
+                    legacy$encodeFace(buffer, offsetX, offsetZ, Direction.EAST, 16);
+                }
+                return;
+            }
+
             if (legacy$isNorthEmpty(cellData) && offsetZ > 0) {
                 legacy$encodeFace(buffer, offsetX, offsetZ, Direction.NORTH, 0);
             }
@@ -222,13 +247,6 @@ public abstract class CloudRendererMixin {
             if (legacy$isEastEmpty(cellData) && offsetX < 0) {
                 legacy$encodeFace(buffer, offsetX, offsetZ, Direction.EAST, 0);
             }
-
-            if (relativeCameraPos == 0 && Math.abs(offsetX) <= INSIDE_FACE_RADIUS && Math.abs(offsetZ) <= INSIDE_FACE_RADIUS) {
-                legacy$encodeFace(buffer, offsetX, offsetZ, Direction.NORTH, 16);
-                legacy$encodeFace(buffer, offsetX, offsetZ, Direction.SOUTH, 16);
-                legacy$encodeFace(buffer, offsetX, offsetZ, Direction.WEST, 16);
-                legacy$encodeFace(buffer, offsetX, offsetZ, Direction.EAST, 16);
-            }
         }
 
     }
@@ -242,11 +260,11 @@ public abstract class CloudRendererMixin {
 
         double cameraY = minecraft.gameRenderer.getMainCamera().getPosition().y;
         float cloudHeight = LegacyCloudAtmosphere.areLegacyCloudHeightAndTextureEnabled() ? LEGACY_CLOUD_HEIGHT : (float) minecraft.level.dimensionType().cloudHeight().orElse((int) LEGACY_CLOUD_HEIGHT);
-        if (cameraY > cloudHeight + CLOUD_LAYER_HEIGHT) {
+        if (cameraY > cloudHeight + CLOUD_BASE_HEIGHT + CLOUD_TOP_EXTENSION) {
             return 1;
         }
 
-        if (cameraY < cloudHeight) {
+        if (cameraY < cloudHeight - CLOUD_BOTTOM_EXTENSION) {
             return -1;
         }
 

--- a/src/main/java/wily/legacy/mixin/base/client/CloudRendererMixin.java
+++ b/src/main/java/wily/legacy/mixin/base/client/CloudRendererMixin.java
@@ -34,6 +34,8 @@ public abstract class CloudRendererMixin {
     @Unique
     private boolean legacy$lastLegacyCloudHeightAndTextureState;
     @Unique
+    private boolean legacy$lastPackCloudShaderState;
+    @Unique
     private boolean legacy$useWarmCloudPipelines;
 
     @Shadow
@@ -48,9 +50,11 @@ public abstract class CloudRendererMixin {
         legacy$useWarmCloudPipelines = minecraft.level != null && LegacyCloudAtmosphere.shouldUseWarmCloudTransparency(minecraft.level, ticks);
         boolean lceCloudsEnabled = LegacyCloudAtmosphere.areLceCloudsEnabled();
         boolean legacyCloudHeightAndTextureEnabled = LegacyCloudAtmosphere.areLegacyCloudHeightAndTextureEnabled();
-        if (legacy$lastLceCloudState != lceCloudsEnabled || legacy$lastLegacyCloudHeightAndTextureState != legacyCloudHeightAndTextureEnabled) {
+        boolean packCloudShaderEnabled = LegacyCloudAtmosphere.shouldUsePackCloudShader();
+        if (legacy$lastLceCloudState != lceCloudsEnabled || legacy$lastLegacyCloudHeightAndTextureState != legacyCloudHeightAndTextureEnabled || legacy$lastPackCloudShaderState != packCloudShaderEnabled) {
             legacy$lastLceCloudState = lceCloudsEnabled;
             legacy$lastLegacyCloudHeightAndTextureState = legacyCloudHeightAndTextureEnabled;
+            legacy$lastPackCloudShaderState = packCloudShaderEnabled;
             needsRebuild = true;
         }
     }
@@ -76,6 +80,10 @@ public abstract class CloudRendererMixin {
             return RenderPipelines.CLOUDS;
         }
 
+        if (LegacyCloudAtmosphere.shouldUsePackCloudShader()) {
+            return LegacyRenderPipelines.LEGACY_PACK_CLOUDS;
+        }
+
         return legacy$useWarmCloudPipelines ? LegacyRenderPipelines.LEGACY_WARM_CLOUDS : LegacyRenderPipelines.LEGACY_CLOUDS;
     }
 
@@ -89,6 +97,10 @@ public abstract class CloudRendererMixin {
     private RenderPipeline legacy$useLegacyFlatCloudPipeline() {
         if (!LegacyCloudAtmosphere.areLceCloudsEnabled()) {
             return RenderPipelines.FLAT_CLOUDS;
+        }
+
+        if (LegacyCloudAtmosphere.shouldUsePackCloudShader()) {
+            return LegacyRenderPipelines.LEGACY_PACK_FLAT_CLOUDS;
         }
 
         return legacy$useWarmCloudPipelines ? LegacyRenderPipelines.LEGACY_WARM_FLAT_CLOUDS : LegacyRenderPipelines.LEGACY_FLAT_CLOUDS;

--- a/src/main/resources/assets/legacy/shaders/core/legacy_rendertype_clouds.vsh
+++ b/src/main/resources/assets/legacy/shaders/core/legacy_rendertype_clouds.vsh
@@ -11,6 +11,7 @@ const int FLAG_EXTRA_Z = 1 << 6;
 const int FLAG_EXTRA_X = 1 << 7;
 const float CLOUD_TOP_EXTENSION = 0.25;
 const float CLOUD_BOTTOM_EXTENSION = 0.6666667;
+const float CLOUD_INSIDE_FACE_OFFSET = 0.02;
 
 layout(std140) uniform CloudInfo {
     vec4 CloudColor;
@@ -60,6 +61,15 @@ const vec4[] faceColors = vec4[](
     vec4(0.9, 0.9, 0.9, 0.8)
 );
 
+const vec3[] faceNormals = vec3[](
+    vec3(0.0, -1.0, 0.0),
+    vec3(0.0, 1.0, 0.0),
+    vec3(0.0, 0.0, -1.0),
+    vec3(0.0, 0.0, 1.0),
+    vec3(-1.0, 0.0, 0.0),
+    vec3(1.0, 0.0, 0.0)
+);
+
 void main() {
     int quadVertex = gl_VertexID % 4;
     int index = (gl_VertexID / 4) * 3;
@@ -76,6 +86,9 @@ void main() {
     vec3 faceVertex = vertices[(direction * 4) + (isInsideFace ? 3 - quadVertex : quadVertex)];
     float y = faceVertex.y > 0.5 ? CellSize.y + CLOUD_TOP_EXTENSION : -CLOUD_BOTTOM_EXTENSION;
     vec3 pos = vec3(faceVertex.x * CellSize.x, y, faceVertex.z * CellSize.z) + (vec3(cellX, 0, cellZ) * CellSize) + CloudOffset;
+    if (isInsideFace) {
+        pos -= faceNormals[direction] * CLOUD_INSIDE_FACE_OFFSET;
+    }
     gl_Position = ProjMat * ModelViewMat * vec4(pos, 1.0);
 
     vertexDistance = fog_spherical_distance(pos);

--- a/src/main/resources/assets/legacy/shaders/core/legacy_rendertype_clouds.vsh
+++ b/src/main/resources/assets/legacy/shaders/core/legacy_rendertype_clouds.vsh
@@ -9,6 +9,8 @@ const int FLAG_INSIDE_FACE = 1 << 4;
 const int FLAG_USE_TOP_COLOR = 1 << 5;
 const int FLAG_EXTRA_Z = 1 << 6;
 const int FLAG_EXTRA_X = 1 << 7;
+const float CLOUD_TOP_EXTENSION = 0.25;
+const float CLOUD_BOTTOM_EXTENSION = 0.6666667;
 
 layout(std140) uniform CloudInfo {
     vec4 CloudColor;
@@ -72,7 +74,8 @@ void main() {
     cellZ = (cellZ << 1) | ((dirAndFlags & FLAG_EXTRA_Z) >> 6);
 
     vec3 faceVertex = vertices[(direction * 4) + (isInsideFace ? 3 - quadVertex : quadVertex)];
-    vec3 pos = (faceVertex * CellSize) + (vec3(cellX, 0, cellZ) * CellSize) + CloudOffset;
+    float y = faceVertex.y > 0.5 ? CellSize.y + CLOUD_TOP_EXTENSION : -CLOUD_BOTTOM_EXTENSION;
+    vec3 pos = vec3(faceVertex.x * CellSize.x, y, faceVertex.z * CellSize.z) + (vec3(cellX, 0, cellZ) * CellSize) + CloudOffset;
     gl_Position = ProjMat * ModelViewMat * vec4(pos, 1.0);
 
     vertexDistance = fog_spherical_distance(pos);


### PR DESCRIPTION
when a resource pack overrides renderclouds it switches back to the vanilla pipeline allowing it to work normally