### PR TITLE
Fixed skin animation bugs

### DIFF
--- a/src/main/java/wily/legacy/mixin/base/skins/client/UpsideDownMixin.java
+++ b/src/main/java/wily/legacy/mixin/base/skins/client/UpsideDownMixin.java
@@ -2,19 +2,35 @@ package wily.legacy.mixin.base.skins.client;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.math.Axis;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.entity.player.AvatarRenderer;
 import net.minecraft.client.renderer.entity.state.AvatarRenderState;
+import net.minecraft.world.entity.Avatar;
+import net.minecraft.world.entity.player.Player;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import wily.legacy.client.LegacyOptions;
 import wily.legacy.skins.client.gui.GuiDollRender;
 import wily.legacy.skins.client.render.RenderStateSkinIdAccess;
 import wily.legacy.skins.pose.SkinPoseRegistry;
+import wily.legacy.skins.skin.ClientSkinCache;
+import wily.legacy.skins.skin.SkinFairness;
+import wily.legacy.skins.skin.SkinIdUtil;
 
 @Mixin(AvatarRenderer.class)
 public abstract class UpsideDownMixin {
+    @Inject(method = "isEntityUpsideDown(Lnet/minecraft/world/entity/Avatar;)Z", at = @At("HEAD"), cancellable = true, require = 0)
+    private void consoleskins$isEntityUpsideDown(Avatar avatar, CallbackInfoReturnable<Boolean> cir) {
+        if (!LegacyOptions.customSkinAnimation.get()) return;
+        if (!(avatar instanceof Player player)) return;
+        String skinId = SkinFairness.effectiveSkinId(Minecraft.getInstance(), ClientSkinCache.get(player.getUUID(), player.getScoreboardName()));
+        if (SkinIdUtil.isBlankOrAutoSelect(skinId)) return;
+        if (SkinPoseRegistry.hasPose(SkinPoseRegistry.PoseTag.UPSIDE_DOWN, skinId)) cir.setReturnValue(true);
+    }
+
     @Inject(method = "setupRotations(Lnet/minecraft/client/renderer/entity/state/AvatarRenderState;Lcom/mojang/blaze3d/vertex/PoseStack;FF)V", at = @At("HEAD"), require = 0)
     private void consoleskins$setupFallFlyingRotations(AvatarRenderState state, PoseStack poseStack, float f, float g, CallbackInfo ci) {
         if (state.id != GuiDollRender.MENU_DOLL_ID && state.isFallFlying && consoleskins$isUpsideDownSkin(state)) {
@@ -30,6 +46,7 @@ public abstract class UpsideDownMixin {
             poseStack.mulPose(Axis.ZP.rotationDegrees(180.0F));
             return;
         }
+        if (state.isUpsideDown) return;
         if (state.isFallFlying) return;
         poseStack.translate(0.0F, state.boundingBoxHeight + 0.1F, 0.0F);
         poseStack.mulPose(Axis.ZP.rotationDegrees(180.0F));

--- a/src/main/java/wily/legacy/mixin/base/skins/client/UpsideDownMixin.java
+++ b/src/main/java/wily/legacy/mixin/base/skins/client/UpsideDownMixin.java
@@ -15,18 +15,29 @@ import wily.legacy.skins.pose.SkinPoseRegistry;
 
 @Mixin(AvatarRenderer.class)
 public abstract class UpsideDownMixin {
+    @Inject(method = "setupRotations(Lnet/minecraft/client/renderer/entity/state/AvatarRenderState;Lcom/mojang/blaze3d/vertex/PoseStack;FF)V", at = @At("HEAD"), require = 0)
+    private void consoleskins$setupFallFlyingRotations(AvatarRenderState state, PoseStack poseStack, float f, float g, CallbackInfo ci) {
+        if (state.id != GuiDollRender.MENU_DOLL_ID && state.isFallFlying && consoleskins$isUpsideDownSkin(state)) {
+            state.isUpsideDown = true;
+        }
+    }
+
     @Inject(method = "setupRotations(Lnet/minecraft/client/renderer/entity/state/AvatarRenderState;Lcom/mojang/blaze3d/vertex/PoseStack;FF)V", at = @At("TAIL"), require = 0)
     private void consoleskins$setupRotations(AvatarRenderState state, PoseStack poseStack, float f, float g, CallbackInfo ci) {
-        if (!LegacyOptions.customSkinAnimation.get()) return;
-        if (!(state instanceof RenderStateSkinIdAccess a)) return;
-        String skinId = a.consoleskins$getSkinId();
-        if (!SkinPoseRegistry.hasPose(SkinPoseRegistry.PoseTag.UPSIDE_DOWN, skinId)) return;
+        if (!consoleskins$isUpsideDownSkin(state)) return;
         if (state.id == GuiDollRender.MENU_DOLL_ID) {
             poseStack.translate(0.0F, 2.0F, 0.0F);
             poseStack.mulPose(Axis.ZP.rotationDegrees(180.0F));
             return;
         }
+        if (state.isFallFlying) return;
         poseStack.translate(0.0F, state.boundingBoxHeight + 0.1F, 0.0F);
         poseStack.mulPose(Axis.ZP.rotationDegrees(180.0F));
+    }
+
+    private static boolean consoleskins$isUpsideDownSkin(AvatarRenderState state) {
+        if (!LegacyOptions.customSkinAnimation.get()) return false;
+        if (!(state instanceof RenderStateSkinIdAccess a)) return false;
+        return SkinPoseRegistry.hasPose(SkinPoseRegistry.PoseTag.UPSIDE_DOWN, a.consoleskins$getSkinId());
     }
 }

--- a/src/main/java/wily/legacy/skins/pose/ZombieArmsPose.java
+++ b/src/main/java/wily/legacy/skins/pose/ZombieArmsPose.java
@@ -1,9 +1,19 @@
 package wily.legacy.skins.pose;
 
+<<<<<<< Updated upstream
+=======
+import net.minecraft.client.model.geom.ModelPart;
+import net.minecraft.client.model.effects.SpearAnimations;
+>>>>>>> Stashed changes
 import net.minecraft.client.model.player.PlayerModel;
 import net.minecraft.client.renderer.entity.state.AvatarRenderState;
 import net.minecraft.world.entity.Pose;
 import net.minecraft.world.entity.player.Player;
+<<<<<<< Updated upstream
+=======
+import net.minecraft.world.item.ItemUseAnimation;
+import net.minecraft.world.item.SwingAnimationType;
+>>>>>>> Stashed changes
 import wily.legacy.skins.client.render.RenderStateSkinIdAccess;
 
 public final class ZombieArmsPose {
@@ -61,7 +71,8 @@ public final class ZombieArmsPose {
                 blocking.right(),
                 blocking.left()
         );
-        ArmPoseSupport.applyAttackSwing(model, state, attackTime);
+        if (isSpearJabbing(state, attackTime)) SpearAnimations.thirdPersonAttackHand(model, state);
+        else ArmPoseSupport.applyAttackSwing(model, state, attackTime);
 
         if (blocking.right()) rightState.restore(model.rightArm, model.rightSleeve);
         else rightState.syncSleeve(model.rightArm, model.rightSleeve);
@@ -69,4 +80,54 @@ public final class ZombieArmsPose {
         if (blocking.left()) leftState.restore(model.leftArm, model.leftSleeve);
         else leftState.syncSleeve(model.leftArm, model.leftSleeve);
     }
+<<<<<<< Updated upstream
+=======
+
+    private static boolean isUsingTrident(Player player) {
+        return player != null && player.isUsingItem() && player.getUseItem().getUseAnimation() == ItemUseAnimation.TRIDENT;
+    }
+
+    private static boolean isSpearJabbing(AvatarRenderState state, float attackTime) {
+        return state != null && attackTime > 0.0F && state.swingAnimationType == SwingAnimationType.STAB;
+    }
+
+    private static void applyTrident(PlayerModel model, AvatarRenderState state, Player player) {
+        float baseX = state != null && state.isCrouching ? -1.2F : -1.55F;
+        model.rightArm.xRot = baseX;
+        model.rightArm.yRot = -0.15F;
+        model.rightArm.zRot = 0.0F;
+        model.leftArm.xRot = baseX;
+        model.leftArm.yRot = 0.15F;
+        model.leftArm.zRot = 0.0F;
+
+        HumanoidArm arm = ArmPoseSupport.getUsedArm(player);
+        ModelPart modelArm = arm == HumanoidArm.RIGHT ? model.rightArm : model.leftArm;
+        float crouchOffset = state != null && state.isCrouching ? CROUCH_OFFSET : 0.0F;
+        float targetX = Mth.clamp(model.head.xRot - TRIDENT_BACK_X_ROT - crouchOffset, -4.4F, 2.6F);
+        modelArm.xRot = Mth.lerp(getTridentRaiseProgress(getTridentUseTicks(state, player)), baseX, targetX);
+        modelArm.yRot = model.head.yRot + (arm == HumanoidArm.RIGHT ? -CROUCH_OFFSET : CROUCH_OFFSET);
+        modelArm.zRot = 0.0F;
+
+        ArmPoseSupport.ArmState.capture(model.rightArm, model.rightSleeve).syncSleeve(model.rightArm, model.rightSleeve);
+        ArmPoseSupport.ArmState.capture(model.leftArm, model.leftSleeve).syncSleeve(model.leftArm, model.leftSleeve);
+    }
+
+    private static float getTridentRaiseProgress(int ticksUsingItem) {
+        return switch (Mth.clamp(ticksUsingItem, 0, TRIDENT_RAISE_TICKS)) {
+            case 0 -> 0.55F;
+            case 1 -> 0.72F;
+            case 2 -> 0.82F;
+            case 3 -> 0.90F;
+            case 4 -> 0.96F;
+            case 5 -> 0.99F;
+            default -> 1.0F;
+        };
+    }
+
+    private static int getTridentUseTicks(AvatarRenderState state, Player player) {
+        int ticks = player.getTicksUsingItem();
+        if (state != null && state.isUsingItem) ticks = Math.max(ticks, Math.round(state.ticksUsingItem));
+        return ticks;
+    }
+>>>>>>> Stashed changes
 }

--- a/src/main/java/wily/legacy/skins/pose/ZombieArmsPose.java
+++ b/src/main/java/wily/legacy/skins/pose/ZombieArmsPose.java
@@ -1,5 +1,6 @@
 package wily.legacy.skins.pose;
 
+import net.minecraft.client.model.HumanoidModel;
 import net.minecraft.client.model.effects.SpearAnimations;
 import net.minecraft.client.model.geom.ModelPart;
 import net.minecraft.client.model.player.PlayerModel;
@@ -35,6 +36,7 @@ public final class ZombieArmsPose {
             applyTrident(model, state, player);
             return;
         }
+        if (isBowAiming(state, player)) return;
 
         ArmPoseSupport.ArmState rightState = ArmPoseSupport.ArmState.capture(model.rightArm, model.rightSleeve);
         ArmPoseSupport.ArmState leftState = ArmPoseSupport.ArmState.capture(model.leftArm, model.leftSleeve);
@@ -87,6 +89,11 @@ public final class ZombieArmsPose {
 
     private static boolean isUsingTrident(Player player) {
         return player != null && player.isUsingItem() && player.getUseItem().getUseAnimation() == ItemUseAnimation.TRIDENT;
+    }
+
+    private static boolean isBowAiming(AvatarRenderState state, Player player) {
+        if (state != null && (state.rightArmPose == HumanoidModel.ArmPose.BOW_AND_ARROW || state.leftArmPose == HumanoidModel.ArmPose.BOW_AND_ARROW)) return true;
+        return player != null && player.isUsingItem() && player.getUseItem().getUseAnimation() == ItemUseAnimation.BOW;
     }
 
     private static boolean isSpearJabbing(AvatarRenderState state, float attackTime) {


### PR DESCRIPTION
- Fixed skins with zombie arms not doing the spear jab or bow draw animations 
- Fixed upside down skins having the wrong rotation when flying with elytra
- Fixed upside down skins heads being locked forward in the inventory preview