### PR TITLE
Minor changes for Options menus

### DIFF
--- a/src/main/java/wily/legacy/client/screen/HelpAndOptionsScreen.java
+++ b/src/main/java/wily/legacy/client/screen/HelpAndOptionsScreen.java
@@ -31,19 +31,19 @@ public class HelpAndOptionsScreen extends RenderableVListScreen {
     private static Screen createMouseSettingsScreen(Screen parent) {
         return new OptionsScreen(parent, new OptionsScreen.Section(
                 Component.translatable("options.mouse_settings.title"),
-                s -> Panel.centered(s, 250, 130),
+                s -> Panel.centered(s, 250, 175, 0, 10),
                 new ArrayList<>(List.of(
                         o -> o.renderableVList.addMultSliderOption(LegacyOptions.of(Minecraft.getInstance().options.sensitivity()), 2),
                         o -> o.renderableVList.addMultSliderOption(LegacyOptions.of(Minecraft.getInstance().options.mouseWheelSensitivity()), 2),
                         o -> o.renderableVList.addOptions(
-                                LegacyOptions.of(Minecraft.getInstance().options.rawMouseInput()),
+                                LegacyOptions.cursorAtFirstInventorySlot,
+                                LegacyOptions.systemCursor,
                                 LegacyOptions.of(Minecraft.getInstance().options.allowCursorChanges()),
                                 LegacyOptions.of(Minecraft.getInstance().options.invertMouseX()),
                                 LegacyOptions.of(Minecraft.getInstance().options.invertMouseY()),
+                                LegacyOptions.of(Minecraft.getInstance().options.rawMouseInput()),
                                 LegacyOptions.of(Minecraft.getInstance().options.discreteMouseScroll()),
-                                LegacyOptions.of(Minecraft.getInstance().options.touchscreen()),
-                                LegacyOptions.cursorAtFirstInventorySlot,
-                                LegacyOptions.systemCursor
+                                LegacyOptions.of(Minecraft.getInstance().options.touchscreen())
                         )))));
     }
 

--- a/src/main/java/wily/legacy/client/screen/HelpAndOptionsScreen.java
+++ b/src/main/java/wily/legacy/client/screen/HelpAndOptionsScreen.java
@@ -36,11 +36,11 @@ public class HelpAndOptionsScreen extends RenderableVListScreen {
                         o -> o.renderableVList.addMultSliderOption(LegacyOptions.of(Minecraft.getInstance().options.sensitivity()), 2),
                         o -> o.renderableVList.addMultSliderOption(LegacyOptions.of(Minecraft.getInstance().options.mouseWheelSensitivity()), 2),
                         o -> o.renderableVList.addOptions(
-                                LegacyOptions.cursorAtFirstInventorySlot,
-                                LegacyOptions.systemCursor,
-                                LegacyOptions.of(Minecraft.getInstance().options.allowCursorChanges()),
                                 LegacyOptions.of(Minecraft.getInstance().options.invertMouseX()),
                                 LegacyOptions.of(Minecraft.getInstance().options.invertMouseY()),
+                                LegacyOptions.systemCursor,
+                                LegacyOptions.of(Minecraft.getInstance().options.allowCursorChanges()),
+                                LegacyOptions.cursorAtFirstInventorySlot,
                                 LegacyOptions.of(Minecraft.getInstance().options.rawMouseInput()),
                                 LegacyOptions.of(Minecraft.getInstance().options.discreteMouseScroll()),
                                 LegacyOptions.of(Minecraft.getInstance().options.touchscreen())

--- a/src/main/java/wily/legacy/client/screen/OptionsScreen.java
+++ b/src/main/java/wily/legacy/client/screen/OptionsScreen.java
@@ -381,7 +381,7 @@ public class OptionsScreen extends PanelVListScreen {
                 () -> Section.ADVANCED_GAME_OPTIONS));
         public static final Section ADVANCED_GAME_OPTIONS = new Section(
                 Component.translatable("legacy.menu.settings.advanced_options", GAME_OPTIONS.title()),
-                s -> Panel.centered(s, 250, 172),
+                s -> Panel.centered(s, 250, 215, 0, 20),
                 new ArrayList<>(List.of(
                         o -> o.renderableVList.addOptionsCategory(
                                 Component.translatable("legacy.menu.in_game_settings"),
@@ -445,7 +445,7 @@ public class OptionsScreen extends PanelVListScreen {
                 () -> Section.ADVANCED_AUDIO));
         public static final Section ADVANCED_AUDIO = new Section(
                 Component.translatable("legacy.menu.settings.advanced_options", AUDIO.title()),
-                s -> Panel.centered(s, 250, 198, 0, 30),
+                s -> Panel.centered(s, 250, 215, 0, 20),
                 new ArrayList<>(List.of(
                         o -> o.renderableVList.addOptions(
                                 LegacyOptions.of(mc.options.soundDevice()),
@@ -701,7 +701,7 @@ public class OptionsScreen extends PanelVListScreen {
                 () -> Section.ADVANCED_USER_INTERFACE));
         public static final Section ADVANCED_USER_INTERFACE = new Section(
                 Component.translatable("legacy.menu.settings.advanced_options", USER_INTERFACE.title()),
-                s -> Panel.centered(s, 250, 184, 0, 18),
+                s -> Panel.centered(s, 250, 215, 0, 20),
                 new ArrayList<>(List.of(
                         o -> o.renderableVList.addOptionsCategory(
                                 Component.translatable("legacy.menu.in_game_settings"),


### PR DESCRIPTION
- Reordered and resized the Mouse Options screen
<img width="1920" height="1080" alt="2026-05-04_00 27 57" src="https://github.com/user-attachments/assets/d1f9bfef-d47d-42cf-bb3f-db3fec238005" />
<br>

- Unified the size of Advanced Options screens (doesn't affect Merge mode due to sizes deriving from the non-Advanced screen)
  - Without Legacy Settings Menus

    <img width="1920" height="1080" alt="2026-05-04_00 22 17" src="https://github.com/user-attachments/assets/f24d1c19-8845-4859-8cc2-5d06eee4b40c" />
    <img width="1920" height="1080" alt="2026-05-04_00 22 22" src="https://github.com/user-attachments/assets/5235c774-80ea-438f-9ec2-5a9ee602da90" />
    <img width="1920" height="1080" alt="2026-05-04_00 22 28" src="https://github.com/user-attachments/assets/7718dd1e-0cb2-42b8-9ba7-c80c9d044248" />
    <img width="1920" height="1080" alt="2026-05-04_00 22 31" src="https://github.com/user-attachments/assets/a7dd1841-a9b9-43d9-a4c4-ef78d24598fa" />

  - With Legacy Settings Menus

    <img width="1920" height="1080" alt="2026-05-04_00 32 42" src="https://github.com/user-attachments/assets/b9c703a1-c73a-4fed-ad83-eacab136734f" />
    <img width="1920" height="1080" alt="2026-05-04_00 32 49" src="https://github.com/user-attachments/assets/63bf0813-e30f-44ea-8621-c2a2dd30800e" />
    <img width="1920" height="1080" alt="2026-05-04_00 32 51" src="https://github.com/user-attachments/assets/9c4374da-3bdb-407c-8094-a94f63315ab8" />
    <img width="1920" height="1080" alt="2026-05-04_00 32 55" src="https://github.com/user-attachments/assets/20f65aee-d243-46c6-a03a-3c213aa2f220" />
