### PR TITLE
fix: prevent IndexOutOfBoundsException in MixedCraftingScreen recipe display

### DIFF
--- a/src/main/java/wily/legacy/client/screen/MixedCraftingScreen.java
+++ b/src/main/java/wily/legacy/client/screen/MixedCraftingScreen.java
@@ -276,7 +276,8 @@ public class MixedCraftingScreen<T extends AbstractCraftingMenu> extends Recipes
                     }
                 }
                 e.craftingRequirements().ifPresent(ingredients -> {
-                    for (int index = 0; index < ingredients.size(); index++) {
+                    int limit = Math.min(ingredients.size(), ings.size());
+                    for (int index = 0; index < limit; index++) {
                         ings.set(index, Optional.of(ingredients.get(index)));
                     }
                 });


### PR DESCRIPTION
## Summary
- Fixes a client crash (`Ticking screen` / `IndexOutOfBoundsException`) that happens while browsing the crafting recipes screen (`MixedCraftingScreen`).
- `e.craftingRequirements()` can return more ingredients than the current recipe grid has slots for. The loop that copies them into `ings` used `ingredients.size()` as the bound instead of the destination list's size, so it could write past the end of `ings` and throw.
- Bounds the loop to `Math.min(ingredients.size(), ings.size())`.

## Crash log (reproduced on 26.1.2-fabric)
```
java.lang.IndexOutOfBoundsException: Index 4 out of bounds for length 4
	at java.base/java.util.ArrayList.set(Unknown Source)
	at wily.legacy.client.screen.MixedCraftingScreen.lambda$updateRecipes$4(MixedCraftingScreen.java:279)
	at java.base/java.util.Optional.ifPresent(Unknown Source)
	at wily.legacy.client.screen.MixedCraftingScreen.lambda$updateRecipes$2(MixedCraftingScreen.java:277)
	...
	at wily.legacy.client.screen.MixedCraftingScreen.updateRecipes(MixedCraftingScreen.java:360)
	at wily.legacy.client.screen.RecipesScreen.updateRecipesAndResetTimer(RecipesScreen.java:61)
	at wily.legacy.client.screen.RecipesScreen.containerTick(RecipesScreen.java:74)
```

## Test plan
- [x] Built `26.1.2-fabric` locally with `./gradlew :26.1.2-fabric:build`
- [x] Installed the patched jar in a live modpack instance (Simply Legacy) that was previously crashing reliably on opening/ticking the recipes screen
- [x] Confirmed the crash no longer reproduces after the fix