### PR TITLE
Fix ressurrection of MC-131440 / MCPE-184973

### DIFF
--- a/src/main/resources/resourcepacks/legacy_resources/assets/legacy/lang/en_us.json
+++ b/src/main/resources/resourcepacks/legacy_resources/assets/legacy/lang/en_us.json
@@ -1,5 +1,5 @@
 {
-  "block.minecraft.bed.no_sleep": "You can only sleep at night and during thunderstorms",
+  "block.minecraft.bed.no_sleep": "You can only sleep at night or during thunderstorms",
   "block.minecraft.bed.not_safe": "You may not rest now, there are monsters nearby",
   "block.minecraft.bed.too_far_away": "You may not rest now, the bed is too far away",
   "block.minecraft.infested_chiseled_stone_bricks": "Silverfish Chiseled Stone Brick",


### PR DESCRIPTION
https://github.com/Wilyicaro/Legacy-Minecraft/commit/656ad6155d3a66266b62fabdd28a7d9f3c2a5bd0: This is not a fix. You just resurrected a bug that was already patched in other editions. Legacy Console Edition would likely take hold as well if it kept getting updates.
- Java: https://bugs.mojang.com/browse/MC/issues/MC-131440
- Bedrock: https://bugs.mojang.com/browse/MCPE/issues/MCPE-184973

According to the bug reports, the message "You can sleep only at night **and** during thunderstorms" implies that both mentioned conditions must be met in order to sleep.

Please see here for more information. https://discord.com/channels/1203542640008892498/1542387261738324029/1542387261738324029

To fix this, we can merge this commit, or we can remove the line to make it fall back to vanilla.