### PR TITLE
Adding menu.shareToLan

### DIFF
--- a/src/main/resources/assets/legacy/lang/en_us.json
+++ b/src/main/resources/assets/legacy/lang/en_us.json
@@ -2277,6 +2277,7 @@
   "legacy.weather_state.clear": "Clear",
   "legacy.weather_state.rain": "Rain",
   "legacy.weather_state.thunder": "Thunder",
+  "menu.shareToLan": "Open to LAN",
   "menu.shareToLan.description": "When enabled, the game will be shared with other players on your local network.",
   "structure.minecraft.ancient_cities": "Ancient Cities",
   "stat.legacy.days_played": "Days Played",


### PR DESCRIPTION
Adding the key for the menu.shareToLan string since it's currently blank in-game.


(p.s. if anyone wants to, they can add the same string to the other English variants)